### PR TITLE
Create ngMaterial baseline

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -32,7 +32,8 @@
             ],
             "styles": [
               "./node_modules/@angular/material/prebuilt-themes/indigo-pink.css",
-              "src/styles.scss"
+              "src/styles.scss",
+              "theme.scss"
             ],
             "scripts": []
           },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,11 +1,13 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
-import {HttpClientModule} from '@angular/common/http'
+import { HttpClientModule } from '@angular/common/http'
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { TodosComponent } from './components/todos/todos.component';
+import {MatCardModule} from '@angular/material/card';
+
 
 @NgModule({
   declarations: [
@@ -16,7 +18,8 @@ import { TodosComponent } from './components/todos/todos.component';
     BrowserModule,
     AppRoutingModule,
     BrowserAnimationsModule,
-    HttpClientModule
+    HttpClientModule,
+    MatCardModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,10 +6,7 @@ import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { TodosComponent } from './components/todos/todos.component';
-import {MatCardModule} from '@angular/material/card';
-import {MatChipsModule} from '@angular/material/chips';
-
-
+import { MaterialModule } from './material.module';
 
 @NgModule({
   declarations: [
@@ -21,8 +18,7 @@ import {MatChipsModule} from '@angular/material/chips';
     AppRoutingModule,
     BrowserAnimationsModule,
     HttpClientModule,
-    MatCardModule,
-    MatChipsModule
+    MaterialModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -7,6 +7,8 @@ import { AppComponent } from './app.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { TodosComponent } from './components/todos/todos.component';
 import {MatCardModule} from '@angular/material/card';
+import {MatChipsModule} from '@angular/material/chips';
+
 
 
 @NgModule({
@@ -19,7 +21,8 @@ import {MatCardModule} from '@angular/material/card';
     AppRoutingModule,
     BrowserAnimationsModule,
     HttpClientModule,
-    MatCardModule
+    MatCardModule,
+    MatChipsModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/components/todos/todos.component.html
+++ b/src/app/components/todos/todos.component.html
@@ -1,2 +1,7 @@
-<mat-card *ngFor="let todo of todos">{{todo.title}}</mat-card>
+<mat-card *ngFor="let todo of todos">
+  {{todo.title}}
+  <mat-chip-list>
+    <mat-chip [ngStyle]="{'background-color': todo.completed ? '#B3FFB4': '#FAFFB3'}">{{todo.completed ? 'Complete' : 'Incomplete'}}</mat-chip>
+  </mat-chip-list>
+</mat-card>
 

--- a/src/app/components/todos/todos.component.html
+++ b/src/app/components/todos/todos.component.html
@@ -1,3 +1,2 @@
-<ul>
-  <li *ngFor="let todo of todos">{{todo.title}}</li>
-</ul>
+<mat-card *ngFor="let todo of todos">{{todo.title}}</mat-card>
+

--- a/src/app/components/todos/todos.component.scss
+++ b/src/app/components/todos/todos.component.scss
@@ -1,0 +1,3 @@
+.mat-card {
+  margin: 4px;
+}

--- a/src/app/material.module.ts
+++ b/src/app/material.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+
+import {MatCardModule} from '@angular/material/card';
+import {MatChipsModule} from '@angular/material/chips';
+
+@NgModule({
+  imports: [
+    MatCardModule,
+    MatChipsModule
+  ],
+  exports: [
+    MatCardModule,
+    MatChipsModule
+  ]
+})
+export class MaterialModule {}

--- a/theme.scss
+++ b/theme.scss
@@ -1,0 +1,39 @@
+@import "~@angular/material/theming";
+// **Be sure that you only ever include this mixin once!**
+@include mat-core();
+
+// Define the default theme (same as the example above).
+$app-primary: mat-palette($mat-indigo);
+$app-accent: mat-palette($mat-pink, A200, A100, A400);
+$app-theme: mat-light-theme(
+  (
+    color: (
+      primary: $app-primary,
+      accent: $app-accent,
+    ),
+  )
+);
+
+// Include the default theme styles (color and default density)
+@include angular-material-theme($app-theme);
+
+// Define an alternate dark theme.
+$dark-primary: mat-palette($mat-blue-grey);
+$dark-accent: mat-palette($mat-amber, A200, A100, A400);
+$dark-warn: mat-palette($mat-deep-orange);
+$dark-theme: mat-dark-theme(
+  (
+    color: (
+      primary: $dark-primary,
+      accent: $dark-accent,
+      warn: $dark-warn,
+    ),
+  )
+);
+
+// Include the dark color styles inside of a block with a CSS class. You can make this
+// CSS class whatever you want. In this example, any component inside of an element with
+// `.unicorn-dark-theme` will be affected by this alternate dark theme instead of the default theme.
+.unicorn-dark-theme {
+  @include angular-material-color($dark-theme);
+}


### PR DESCRIPTION
Adds theme (unused so far)

Scopes ngMaterial imports to its own module outside of `app.module`

Tests it out with an array of todo cards with colored chips by todo completion status.

Closes #9 (Add ngMaterial theme)
Closes #10 (Place ngMaterial imports in own module)